### PR TITLE
Fixed a crash when encoding objects

### DIFF
--- a/src/Classes/Operators.swift
+++ b/src/Classes/Operators.swift
@@ -20,7 +20,7 @@ public func <-> <T>(left: inout T?, right: Mapping) throws where T: Codable {
     if right.map.type.isDecoding {
         try left <<- right
     } else {
-        try left! ->> right
+        try left ->> right
     }
 }
 
@@ -36,7 +36,7 @@ public func <-> <T>(left: inout [T]?, right: Mapping) throws where T: Codable {
     if right.map.type.isDecoding {
         try left <<- right
     } else {
-        try left! ->> right
+        try left ->> right
     }
 }
 
@@ -65,7 +65,9 @@ public func ->> <T>(left: T, right: Mapping) throws where T: Encodable {
 }
 
 public func ->> <T>(left: T?, right: Mapping) throws where T: Encodable {
-    try right.map.encode(object: left!, with: right.key, options: right.options)
+    if let left = left {
+        try right.map.encode(object: left, with: right.key, options: right.options)
+    }
 }
 
 public func ->> <T>(left: [T], right: Mapping) throws where T: Encodable {
@@ -73,5 +75,7 @@ public func ->> <T>(left: [T], right: Mapping) throws where T: Encodable {
 }
 
 public func ->> <T>(left: [T]?, right: Mapping) throws where T: Encodable {
-    try right.map.encode(object: left!, with: right.key, options: right.options)
+    if let left = left {
+        try right.map.encode(object: left, with: right.key, options: right.options)
+    }
 }


### PR DESCRIPTION
When encoding objects with optional properties, if some property was actually nil, it would produce a crash. This was due to a implicitly unwrapping the optionals in the library. I fixed it to use `if let` optional binding.